### PR TITLE
[frontend] feat: gpt와 채팅 기능

### DIFF
--- a/frontend/stt_diary/src/App.js
+++ b/frontend/stt_diary/src/App.js
@@ -73,7 +73,7 @@ function App() {
         <Route path='/' element={<DiaryList />}/>
         <Route path='/analysis' element={<SentimentReport/>}/>
         <Route path='/create-diary' element={<CreateDiary/>}/>
-        <Route path='/consulting' element={<Consulting/>} />
+        <Route path='/consulting/:id' element={<Consulting/>} />
         <Route path='/detail-diary/:id' element={<DetailDiary/>}/>
         <Route path='/result/:id' element={<SentimentResult/>}/>
         <Route path='/login' element={<Login/>}/>

--- a/frontend/stt_diary/src/routes/Consulting.css
+++ b/frontend/stt_diary/src/routes/Consulting.css
@@ -78,6 +78,7 @@ div {
   font-size: 16px;
   border: none;
   outline: none;
+  background: transparent
 }
 
 #submit-btn {
@@ -101,6 +102,7 @@ div {
   border-radius: 20px;
   border: none;
   background-color: #FDA9BB;
+  cursor: pointer;
 }
 
 /* chat message */
@@ -146,6 +148,24 @@ div {
   left: 16px;
   top: 10px;
   display: none;
+}
+
+.spinner {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 4px solid #000;
+  border-top-color: white;
+  animation: rotate 1s infinite linear;
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @media screen and (max-width: 992px) {

--- a/frontend/stt_diary/src/routes/Consulting.js
+++ b/frontend/stt_diary/src/routes/Consulting.js
@@ -54,6 +54,14 @@ function Consulting() {
     });
   }, []);
   
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      alert('상담이 종료됐습니다.');
+      navigate('/');
+    }, 1 * 60 * 1000);
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
   const sendMessage = (content) => {
     setIsLoading(true);
     let messageCopy = [...message];
@@ -104,7 +112,7 @@ function Consulting() {
                 <div className='chat bot'>
                   <img className='bot-profile' src={require('../assets/chat-profile.png')} alt='bot-profile' />
                   <div className='message'>
-                    안녕하세요! 심리상담 챗봇입니다. <br/>
+                    안녕하세요! 심리상담 챗봇입니다. 상담은 20분 뒤 자동 종료됩니다. <br/>
                     어떤 문제로 도와드릴까요?
                   </div>
                 </div>

--- a/frontend/stt_diary/src/routes/SentimentResult.js
+++ b/frontend/stt_diary/src/routes/SentimentResult.js
@@ -103,7 +103,7 @@ function SentimentResult() {
                     {resultAnalysis}
                 </div>
                 {result === 'negative' && 
-                    <button className='consulting-btn'>상담하기</button>
+                    <button className='consulting-btn' onClick={()=>navigate(`/consulting/${id}`)}>상담하기</button>
                 }
             </div>
         </div>


### PR DESCRIPTION
- 상담버튼을 클릭하면 담 페이지로 이동
- gpt와 채팅 api 연결
- 서버의 res 기다리는 동안 spinner 로딩, 입력란 disabled
- spinner 로딩 사라졌을 때 입력란에 auto focus 
- 종료 버튼을 클릭하면 메인 페이지로 이동